### PR TITLE
Ensure use of v2.x.x of bytes module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "lennym/busboy-body-parser",
   "dependencies": {
     "busboy": "^0.2.9",
-    "bytes": "^1.0.0",
+    "bytes": "^2.0.0",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.0"
   },


### PR DESCRIPTION
The bytes npm module has undergone a major rewrite between version 1.x and version 2.x - https://www.npmjs.com/package/bytes. This includes better parsing of strings or numbers, and mixed case definitions of kilobytes, megabytes, terabytes etc.

This PR amends the package.json to get hold of the latest 2.x.x version. 
