### PR TITLE
Allow multiple attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ app.use(busboyBodyParser({ limit: '5mb' }));
 
 This limit can be defined as either a number of bytes, or any string supported by [bytes](https://www.npmjs.org/package/bytes) - eg. `'5mb'`, `'500kb'`.
 
+### Allow multiple files on a given request
+
+Multiple files with the same key is supported with the `multi` option, hence making `req.files[key]` an array instead of an object.
+
+```javascript
+var busboyBodyParser = require('busboy-body-parser');
+app.use(busboyBodyParser({ multi: true }));
+```
+
 ## Output
 
 The middleware will add files to `req.files` in the following form:
@@ -57,6 +66,21 @@ If a file has exceeded the file-size limit defined above it will have `data: nul
         mimetype: "text/plain",
         truncated: true
     }
+}
+```
+
+If the `multi` property is set:
+
+```
+// req.files:
+{
+    fieldName: [{
+        data: "raw file data",
+        name: "upload.txt",
+        encoding: "utf8",
+        mimetype: "text/plain",
+        truncated: false
+    }]
 }
 ```
 


### PR DESCRIPTION
Since busboy can fire the event 'file' multiple times for a given key, we allow
to specify the 'multi' property making req.files an array instead of an object,
thus supporting multiple files with the same key on a given request.

This is related to #3 except that here `multi` is not a default and the standard behavior is not altered.
