### PR TITLE
avoid crash when file is too large

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var Busboy = require('busboy'),
     bytes = require('bytes'),
     concat = require('concat-stream'),
-    debug = require('debug')('busboy-body-parser');
+    debug = require('debug')('busboy-body-parser'),
+    buffer = require('buffer');
 
 module.exports = function (settings) {
 
@@ -34,7 +35,7 @@ module.exports = function (settings) {
             busboy.on('file', function (key, file, name, enc, mimetype) {
                 file.pipe(concat(function (d) {
                     var size = -1;
-                    if (d.length < Buffer.kMaxLength) {
+                    if (d.length < buffer.kMaxLength) {
                         size = Buffer.byteLength(d.toString('binary'), 'binary');
                     }
 

--- a/index.js
+++ b/index.js
@@ -33,13 +33,18 @@ module.exports = function (settings) {
             });
             busboy.on('file', function (key, file, name, enc, mimetype) {
                 file.pipe(concat(function (d) {
+                    var size = -1;
+                    if (d.length < Buffer.kMaxLength) {
+                        size = Buffer.byteLength(d.toString('binary'), 'binary');
+                    }
+
                     var fileData = {
                         data: file.truncated ? null : d,
                         name: name,
                         encoding: enc,
                         mimetype: mimetype,
                         truncated: file.truncated,
-                        size: Buffer.byteLength(d.toString('binary'), 'binary')
+                        size: size
                     };
 
                     debug('Received file %s', file);


### PR DESCRIPTION
Currently if the file is too large, Buffer.toString will crash. The limit is in V8 and we cannot fix the root cause but at least we can workaround it.