### PR TITLE
Set a hard limit on the maximum file size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,26 @@
 var Busboy = require('busboy'),
     bytes = require('bytes'),
     concat = require('concat-stream'),
+    buffer = require('buffer'),
     debug = require('debug')('busboy-body-parser');
+
+var HARDLIMIT = bytes('250mb');
 
 module.exports = function (settings) {
 
     settings = settings || {};
-    settings.limit = settings.limit || Math.Infinity;
+    settings.limit = settings.limit || HARDLIMIT;
     settings.multi = settings.multi || false;
 
     if (typeof settings.limit === 'string') {
         settings.limit = bytes(settings.limit);
+    }
+
+    if (settings.limit > HARDLIMIT) {
+        console.error('WARNING: busboy-body-parser file size limit set too high');
+        console.error('busboy-body-parser can only handle files up to ' + HARDLIMIT + ' bytes');
+        console.error('to handle larger files you should use a streaming solution.');
+        settings.limit = HARDLIMIT;
     }
 
     return function multipartBodyParser(req, res, next) {
@@ -39,7 +49,7 @@ module.exports = function (settings) {
                         encoding: enc,
                         mimetype: mimetype,
                         truncated: file.truncated,
-                        size: Buffer.byteLength(d.toString('binary'), 'binary')
+                        size: file.truncated ? null : Buffer.byteLength(d, 'binary')
                     };
 
                     debug('Received file %s', file);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var Busboy = require('busboy'),
     bytes = require('bytes'),
     concat = require('concat-stream'),
-    buffer = require('buffer'),
     debug = require('debug')('busboy-body-parser');
 
 var HARDLIMIT = bytes('250mb');

--- a/test/index.js
+++ b/test/index.js
@@ -124,7 +124,7 @@ describe('multipart form parser', function () {
                 name: 'test.jpg',
                 encoding: 'binary',
                 mimetype: 'image/jpeg',
-                size: 6,
+                size: null,
                 truncated: true
             });
             done();


### PR DESCRIPTION
Node/V8 cannot handle strings longer than 256mb and attempts to determine the length of a buffer in excess of this value will throw an error.

Since this module is not intended for large files - where a streaming solution is more appropriate - then set a hard limit of 250mb for the file size, and truncate files larger than that.

The limit is set to 250mb rather than 256mb because busboy will truncate only after the limit is *passed* and so will potentially create buffers slightly longer than the maximum length. Setting to just under the limit allows for this to occur without crashing.