### PR TITLE
Allow support for files with no name

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,10 @@ module.exports = function (settings) {
             });
             busboy.on('file', function (key, file, name, enc, mimetype) {
                 file.pipe(bl(function (err, d) {
-                    if (err || !name) { return; }
+                    if (err || !(d.length || name)) { return; }
                     var fileData = {
                         data: file.truncated ? null : d,
-                        name: name,
+                        name: name || null,
                         encoding: enc,
                         mimetype: mimetype,
                         truncated: file.truncated,

--- a/test/index.js
+++ b/test/index.js
@@ -214,4 +214,28 @@ describe('multipart form parser', function () {
         });
     });
 
+    it('can handle files without a name', function (done) {
+        var file = {
+            pipe: function (s) {
+                s.end('abc123');
+                // ensure 'finish' event fires after files are processed
+                process.nextTick(Busboy.prototype.on.withArgs('finish').args[0][1]);
+            },
+            truncated: true
+        };
+        Busboy.prototype.on.withArgs('file').yieldsAsync('key', file, undefined, '7bit', 'application/octet-stream');
+        parser(req, res, function () {
+            req.files.should.have.property('key');
+            req.files.key.should.eql({
+                data: null,
+                name: null,
+                encoding: '7bit',
+                mimetype: 'application/octet-stream',
+                size: null,
+                truncated: true
+            });
+            done();
+        });
+    });
+
 });


### PR DESCRIPTION
If a file is uploaded from a source other than an html form it is reasonable for it not to be named. Don't rely only on the name property existing to establish if a file is present. Instead assume that am empty buffer, with no name is not a file and that if either a name _or_ any data is present, then treat as a file.

Fixes #23 