### PR TITLE
Add JSDoc to main function in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,15 @@ var Busboy = require('busboy'),
 
 var HARDLIMIT = bytes('250mb');
 
+/**
+ * @description Returns middleware for parsing multipart/form-data bodies. 
+ * Uploaded files are added to req.files while other fields are simply added to req.body.
+ * @example <caption>Example usage that limits file sizes to 3 megabytes:</caption>
+ * const formParser = require('busboy-body-parser'); 
+ * const app = require('express')();
+ * 
+ * app.use(formParser({ limit: '3mb' }));
+ */
 module.exports = function (settings) {
 
     settings = settings || {};


### PR DESCRIPTION
Adding JSDoc to the main function in index.js will give future users a description of what this module returns and an example usage. This will help users who want a basic description and example of this module without having to read this Github repository's README or the package page at npm.